### PR TITLE
Feat/ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tag')
+    steps:
+    - uses: actions/checkout@v2
+    # Setup .npmrc file to publish to GitHub Packages
+    - name: Use Node Version 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        # Default to org scope
+        scope: '@native-elements'
+    - run: yarn
+    - name: Publish package
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postbuild": "run-s copy:source copy:props size",
     "release": "git pull && standard-version --release-as patch && git push --follow-tags",
     "release:minor": "git pull && standard-version --release-as minor && git push --follow-tags",
-    "prepublishOnly": "run-s build",
+    "prepack": "run-s build",
     "size": "size-limit"
   },
   "files": [


### PR DESCRIPTION
This pull request will add a GitHub Action for deploy the package to NPM on pushed `tags`.

You will be able to release running `yarn release` from your local machine and let the CI do the rest.

**NOTE**:
You need to add a secret to the repo with a release token from NPM called `NPM_TOKEN`