### PR TITLE
FIX: content-box on details children

### DIFF
--- a/src/elements/core/ne-core.pcss
+++ b/src/elements/core/ne-core.pcss
@@ -4,7 +4,6 @@ html {
   text-rendering: geometricPrecision;
   -webkit-font-smoothing: antialiased;
   -webkit-touch-callout: none;
-  box-sizing: border-box;
   background: env(--globalBackground);
   color: env(--globalForeground);
 }
@@ -25,7 +24,7 @@ body {
 *,
 *::before,
 *::after {
-  box-sizing: inherit;
+  box-sizing: border-box;
 }
 
 ::selection {


### PR DESCRIPTION
If the box-sizing is set to inherit from the html.
The child elements of a html details element will receive content-box as inherit from the details.