### PR TITLE
fix: replace deprecated :matches() selector with :is()

### DIFF
--- a/src/elements/ne-textfield/ne-textfield.pcss
+++ b/src/elements/ne-textfield/ne-textfield.pcss
@@ -1,4 +1,4 @@
-input:matches(
+input:is(
 [type='text'],
 [type='number'],
 [type='email'],


### PR DESCRIPTION
Replaces the deprecated `:matches()` selector with `:is()`.

Text fields are currently broken for me in Chrome and Chromium 98, I guess due to lack of support for the :matches() selector. This is my quick fix, as :is() is now better supported. Can't say it's worth using postcss-preset-env to keep compatibility with older browsers.